### PR TITLE
Tweak the 2021q3 OpenSSH entry

### DIFF
--- a/2021q3/openssh.adoc
+++ b/2021q3/openssh.adoc
@@ -1,31 +1,32 @@
-== Base System OpenSSH update
+== Base System OpenSSH Update
 
 Links: +
-link:https://www.openssh.com/[OpenSSH] URL: https://www.openssh.com/ +
-link:https://lists.freebsd.org/pipermail/freebsd-security/2021-September/010473.html[Mailing list posting] URL: https://lists.freebsd.org/pipermail/freebsd-security/2021-September/010473.html
+link:https://www.openssh.com/[OpenSSH] URL: link:https://www.openssh.com/[https://www.openssh.com/] +
+link:https://lists.freebsd.org/pipermail/freebsd-security/2021-September/010473.html[Announcement to freebsd-security@] URL: link:https://lists.freebsd.org/pipermail/freebsd-security/2021-September/010473.html[https://lists.freebsd.org/pipermail/freebsd-security/2021-September/010473.html]
 
 Contact: Ed Maste <emaste@freebsd.org>
 
-OpenSSH is a suite of remote login and file transfer servers and client
-tools.  OpenSSH in the base system has been updated from version 7.9p1 to
-8.7p1.
+OpenSSH, a suite of remote login and file transfer tools, was updated from
+version 7.9p1 to 8.7p1 in the FreeBSD base system.
 
-We have a number of local bug fixes, configuration changes, and small features
-in our base system version of OpenSSH.  As part of the work for this update
-I submitted some of these upstream, and am preparing to do the same with the
-remaining ones.
+FreeBSD base OpenSSH includes a number of local bug fixes, configuration
+changes, and small features.  As part of the work for this update, I submitted
+some of these upstream and am preparing to do the same with the remaining
+changes.
 
-OpenSSH now supports FIDO/U2F devices, although additional work is required
-to enable this in the FreeBSD base system.  This includes importing a pair
-of dependencies: libcbor, and libfido2.
+OpenSSH now supports https://en.wikipedia.org/wiki/FIDO2_Project[FIDO] /
+https://en.wikipedia.org/wiki/Universal_2nd_Factor[U2F] devices, although
+additional work is required to enable this in the FreeBSD base system.  This
+includes importing a pair of dependencies:
+https://github.com/PJK/libcbor[libcbor], and
+https://github.com/Yubico/libfido2[libfido2].  Within the next couple of months
+I expect to enable FIDO / U2F support, and update to OpenSSH version 8.8p1.
 
-Within the next couple of months I expect to enable FIDO/U2F support, and
-update to OpenSSH version 8.8p1.
-
-NOTE: OpenSSH 8.8p1 will disable the ssh-rsa signature scheme by default,
-so some additional work is required for this next update.  For more information
+*NOTE*:
+OpenSSH 8.8p1 will disable the ssh-rsa signature scheme by default, so
+some additional work is required for this next update.  For more information
 please see the
-link:https://lists.freebsd.org/pipermail/freebsd-security/2021-September/010473.html[Important note for future FreeBSD base system OpenSSH update]
-mailing list post.
+https://lists.freebsd.org/pipermail/freebsd-security/2021-September/010473.html[Important
+note for future FreeBSD base system OpenSSH update] mailing list post.
 
 Sponsor: The FreeBSD Foundation

--- a/2021q3/openssh.adoc
+++ b/2021q3/openssh.adoc
@@ -14,19 +14,19 @@ changes, and small features.  As part of the work for this update, I submitted
 some of these upstream and am preparing to do the same with the remaining
 changes.
 
-OpenSSH now supports https://en.wikipedia.org/wiki/FIDO2_Project[FIDO] /
-https://en.wikipedia.org/wiki/Universal_2nd_Factor[U2F] devices, although
-additional work is required to enable this in the FreeBSD base system.  This
-includes importing a pair of dependencies:
+OpenSSH now supports
+link:https://en.wikipedia.org/wiki/FIDO2_Project[FIDO]/link:https://en.wikipedia.org/wiki/Universal_2nd_Factor[U2F]
+devices, although additional work is required to enable this in the FreeBSD base
+system.  This includes importing a pair of dependencies:
 https://github.com/PJK/libcbor[libcbor], and
 https://github.com/Yubico/libfido2[libfido2].  Within the next couple of months
-I expect to enable FIDO / U2F support, and update to OpenSSH version 8.8p1.
+I expect to enable FIDO/U2F support, and update to OpenSSH version 8.8p1.
 
 *NOTE*:
 OpenSSH 8.8p1 will disable the ssh-rsa signature scheme by default, so
 some additional work is required for this next update.  For more information
 please see the
-https://lists.freebsd.org/pipermail/freebsd-security/2021-September/010473.html[Important
+link:https://lists.freebsd.org/pipermail/freebsd-security/2021-September/010473.html[Important
 note for future FreeBSD base system OpenSSH update] mailing list post.
 
 Sponsor: The FreeBSD Foundation


### PR DESCRIPTION
The additional space in FIDO / U2F was necessary for the second link to work.
If you don't want the links the original spacing can be used.